### PR TITLE
Проверить расчеты по всему проекту

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,9 @@
     "": {
       "name": "elgato-cash",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
-        "@prisma/client": "^5.19.1",
+        "@prisma/client": "^5.22.0",
         "next": "15.5.0",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -21,7 +22,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
-        "prisma": "^5.19.1",
+        "prisma": "^5.22.0",
         "tailwindcss": "^4",
         "typescript": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -13,21 +13,21 @@
     "db:reset": "prisma migrate reset --force --skip-generate"
   },
   "dependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "@prisma/client": "^5.22.0",
     "next": "15.5.0",
-    "@prisma/client": "^5.19.1"
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
-    "@eslint/eslintrc": "^3",
-    "prisma": "^5.19.1"
+    "prisma": "^5.22.0",
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -20,8 +20,9 @@ export default async function ReportsPage({ searchParams }: { searchParams: Prom
     const w = workers.find((w: { id: number }) => w.id === row.workerId)
     if (!byWorker.has(row.workerId)) byWorker.set(row.workerId, { name: w?.name ?? '', cash: 0, noncash: 0 })
     const rec = byWorker.get(row.workerId)!
-    if (row.method === 'cash') rec.cash = Number(row._sum.amount ?? 0)
-    else rec.noncash = Number(row._sum.amount ?? 0)
+    const amount = Number((row as any)._sum?.amount ?? 0)
+    if (row.method === 'cash') rec.cash += amount
+    else rec.noncash += amount
   }
 
   const sales = await prisma.productSale.groupBy({
@@ -83,7 +84,7 @@ export default async function ReportsPage({ searchParams }: { searchParams: Prom
                     totalSales={totalSales}
                     totalPayouts={totalPayouts}
                   />
-                  <WorkersServicesTable workersServices={byWorker} />
+                  <WorkersServicesTable workersServices={byWorker} payoutsByWorker={payoutsMap} />
                 </>
               )
             },

--- a/src/components/shifts/ShiftSummary.tsx
+++ b/src/components/shifts/ShiftSummary.tsx
@@ -40,6 +40,7 @@ function StatCard({ title, value, color, subtitle }: {
 function PaymentMethodsSummary({ paymentMethods }: { paymentMethods: ShiftSummaryProps['paymentMethods'] }) {
   const totalCash = paymentMethods.cash
   const totalNonCash = paymentMethods.noncash + paymentMethods.transfer + paymentMethods.sbp
+  const denom = totalCash + totalNonCash
 
   return (
     <div className="mt-6 p-4 bg-gray-50 border border-gray-200 rounded-lg">
@@ -50,28 +51,28 @@ function PaymentMethodsSummary({ paymentMethods }: { paymentMethods: ShiftSummar
           title="Наличные"
           value={`${totalCash.toFixed(2)} ₽`}
           color="text-green-600"
-          subtitle={`${((totalCash / (totalCash + totalNonCash)) * 100).toFixed(1)}%`}
+          subtitle={`${denom > 0 ? ((totalCash / denom) * 100).toFixed(1) : '0.0'}%`}
         />
 
         <StatCard
           title="Безналичные"
           value={`${paymentMethods.noncash.toFixed(2)} ₽`}
           color="text-blue-600"
-          subtitle={`${((paymentMethods.noncash / (totalCash + totalNonCash)) * 100).toFixed(1)}%`}
+          subtitle={`${denom > 0 ? ((paymentMethods.noncash / denom) * 100).toFixed(1) : '0.0'}%`}
         />
 
         <StatCard
           title="Переводы"
           value={`${paymentMethods.transfer.toFixed(2)} ₽`}
           color="text-yellow-600"
-          subtitle={`${((paymentMethods.transfer / (totalCash + totalNonCash)) * 100).toFixed(1)}%`}
+          subtitle={`${denom > 0 ? ((paymentMethods.transfer / denom) * 100).toFixed(1) : '0.0'}%`}
         />
 
         <StatCard
           title="СБП"
           value={`${paymentMethods.sbp.toFixed(2)} ₽`}
           color="text-purple-600"
-          subtitle={`${((paymentMethods.sbp / (totalCash + totalNonCash)) * 100).toFixed(1)}%`}
+          subtitle={`${denom > 0 ? ((paymentMethods.sbp / denom) * 100).toFixed(1) : '0.0'}%`}
         />
       </div>
     </div>
@@ -81,8 +82,8 @@ function PaymentMethodsSummary({ paymentMethods }: { paymentMethods: ShiftSummar
 export default function ShiftSummary({ shift, totalSales, totalServices, totalPayouts, paymentMethods }: ShiftSummaryProps) {
   const isShiftClosed = shift.closingCash !== null
   const totalIncome = totalSales + totalServices
-  const netProfit = totalIncome - totalPayouts
-  const expectedCash = shift.openingCash + netProfit
+  // Ожидаемая касса учитывает только наличные поступления
+  const expectedCash = shift.openingCash + paymentMethods.cash - totalPayouts
 
   return (
     <Card title="Итоги смены" className="mb-6">

--- a/src/components/tables/ServicesTable.tsx
+++ b/src/components/tables/ServicesTable.tsx
@@ -62,18 +62,28 @@ export default function ServicesTable({ shift, services, workers }: ServicesTabl
 
   // Функция для форматирования суммы в денежный формат рублей
   const formatCurrency = (value: string | number): string => {
-    const numValue = typeof value === 'string' ? parseFloat(value) || 0 : value
+    const numValue = typeof value === 'string' ? (value === '' ? 0 : Number(value.replace(/,/g, '.'))) || 0 : value
     return new Intl.NumberFormat('ru-RU', {
       style: 'currency',
       currency: 'RUB',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2
     }).format(numValue)
   }
 
   // Функция для очистки введенного значения от форматирования
   const cleanCurrencyValue = (value: string): string => {
-    return value.replace(/[^\d]/g, '')
+    // Сохраняем десятичную точку/запятую, убираем прочие символы
+    const cleaned = value
+      .replace(/\s/g, '')
+      .replace(/(\.|,)(?=.*(\.|,))/g, '') // оставить только первый разделитель
+      .replace(',', '.')
+      .replace(/[^0-9.]/g, '')
+    // Ограничим до двух знаков после точки
+    const match = cleaned.match(/^(\d+)(?:\.(\d{0,2}))?$/)
+    if (!match) return cleaned
+    const [, intPart, fracPart = ''] = match
+    return fracPart === '' ? intPart : `${intPart}.${fracPart}`
   }
 
   // Состояние для выбранных мастеров в смене
@@ -215,7 +225,7 @@ export default function ServicesTable({ shift, services, workers }: ServicesTabl
     const value = cellValues[cellKey]
     if (value) {
       const cleanValue = cleanCurrencyValue(value)
-      const numeric = parseFloat(cleanValue)
+      const numeric = Number(cleanValue)
 
       if (cleanValue && numeric > 0) {
         // Показываем выбор метода оплаты

--- a/src/components/tables/WorkersServicesTable.tsx
+++ b/src/components/tables/WorkersServicesTable.tsx
@@ -3,9 +3,10 @@ import { Badge } from '../ui'
 
 interface WorkersServicesTableProps {
   workersServices: Map<number, { name: string; cash: number; noncash: number }>
+  payoutsByWorker?: Map<number, number>
 }
 
-export default function WorkersServicesTable({ workersServices }: WorkersServicesTableProps) {
+export default function WorkersServicesTable({ workersServices, payoutsByWorker }: WorkersServicesTableProps) {
   return (
     <Card title="Услуги по сотрудникам">
       <Table>
@@ -26,19 +27,24 @@ export default function WorkersServicesTable({ workersServices }: WorkersService
               </TableCell>
             </TableRow>
           ) : (
-            Array.from(workersServices.entries()).map(([workerId, data]) => (
-              <TableRow key={workerId}>
-                <TableCell className="font-medium">{data.name}</TableCell>
-                <TableCell>
-                  <Badge variant="primary">Мастер</Badge>
-                </TableCell>
-                <TableCell className="font-mono text-green-600">{(data.cash + data.noncash).toFixed(2)} ₽</TableCell>
-                <TableCell className="font-mono text-red-600">0.00 ₽</TableCell>
-                <TableCell className="font-mono font-semibold text-green-600">
-                  {(data.cash + data.noncash).toFixed(2)} ₽
-                </TableCell>
-              </TableRow>
-            ))
+            Array.from(workersServices.entries()).map(([workerId, data]) => {
+              const payouts = payoutsByWorker?.get(workerId) ?? 0
+              const services = data.cash + data.noncash
+              const net = services - payouts
+              return (
+                <TableRow key={workerId}>
+                  <TableCell className="font-medium">{data.name}</TableCell>
+                  <TableCell>
+                    <Badge variant="primary">Мастер</Badge>
+                  </TableCell>
+                  <TableCell className="font-mono text-green-600">{services.toFixed(2)} ₽</TableCell>
+                  <TableCell className="font-mono text-red-600">{payouts.toFixed(2)} ₽</TableCell>
+                  <TableCell className={`font-mono font-semibold ${net >= 0 ? 'text-green-600' : 'text-red-700'}`}>
+                    {net.toFixed(2)} ₽
+                  </TableCell>
+                </TableRow>
+              )
+            })
           )}
         </TableBody>
         <tfoot>
@@ -50,10 +56,14 @@ export default function WorkersServicesTable({ workersServices }: WorkersService
               {Array.from(workersServices.values()).reduce((sum, data) => sum + data.cash + data.noncash, 0).toFixed(2)} ₽
             </td>
             <td className="border border-gray-300 p-3 font-semibold text-gray-900 font-mono text-red-600">
-              0.00 ₽
+              {Array.from(payoutsByWorker?.values() ?? []).reduce((sum, p) => sum + p, 0).toFixed(2)} ₽
             </td>
             <td className="border border-gray-300 p-3 font-semibold text-gray-900 font-mono">
-              {Array.from(workersServices.values()).reduce((sum, data) => sum + data.cash + data.noncash, 0).toFixed(2)} ₽
+              {(() => {
+                const totalServices = Array.from(workersServices.values()).reduce((sum, data) => sum + data.cash + data.noncash, 0)
+                const totalPayouts = Array.from(payoutsByWorker?.values() ?? []).reduce((sum, p) => sum + p, 0)
+                return (totalServices - totalPayouts).toFixed(2)
+              })()} ₽
             </td>
           </tr>
         </tfoot>


### PR DESCRIPTION
Fix calculation errors in shift summaries, reports, and service entries to ensure all sums, cash/non-cash splits, and payouts are accurately accounted for.

This PR addresses the reported inconsistencies by:
- Correcting `ShiftSummary` to calculate expected cash based on cash payments minus payouts and adding division-by-zero guards for percentages.
- Updating `reports/page.tsx` to cumulatively aggregate cash and non-cash amounts and pass payout data to the worker services table.
- Enhancing `WorkersServicesTable` to display individual and total payouts and net amounts per worker.
- Improving `ServicesTable` to consistently preserve two decimal places for currency inputs and displays.
- Updating Prisma to `5.22.0`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2096f0aa-370e-4ade-9a22-1af3c1e35d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2096f0aa-370e-4ade-9a22-1af3c1e35d7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

